### PR TITLE
[codex] Add lab impair apply and clear

### DIFF
--- a/internal/cli/lab.go
+++ b/internal/cli/lab.go
@@ -80,6 +80,7 @@ func newLabImpairApplyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "apply",
 		Short: "Apply impairments to a node",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			result, err := lab.Apply(context.Background(), lab.ApplyOptions{
 				Node:   node,
@@ -108,6 +109,7 @@ func newLabImpairClearCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "clear",
 		Short: "Clear impairments from a node",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			result, err := lab.Clear(context.Background(), lab.ClearOptions{Node: node})
 			if err != nil {
@@ -139,6 +141,7 @@ func newLabApplyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "apply",
 		Short: "Apply impairments to a node",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			result, err := lab.Apply(context.Background(), lab.ApplyOptions{
 				Node:   node,

--- a/internal/cli/lab.go
+++ b/internal/cli/lab.go
@@ -18,6 +18,7 @@ func newLabCmd() *cobra.Command {
 	cmd.AddCommand(
 		newLabCreateCmd(),
 		newLabApplyCmd(),
+		newLabImpairCmd(),
 		newLabShowCmd(),
 		newLabDestroyCmd(),
 	)
@@ -55,6 +56,79 @@ func newLabCreateCmd() *cobra.Command {
 	return cmd
 }
 
+func newLabImpairCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "impair",
+		Short: "Manage node network impairments",
+	}
+
+	cmd.AddCommand(
+		newLabImpairApplyCmd(),
+		newLabImpairClearCmd(),
+	)
+
+	return cmd
+}
+
+func newLabImpairApplyCmd() *cobra.Command {
+	var node string
+	var delay string
+	var loss string
+	var jitter string
+	var bw string
+
+	cmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Apply impairments to a node",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := lab.Apply(context.Background(), lab.ApplyOptions{
+				Node:   node,
+				Delay:  delay,
+				Loss:   loss,
+				Jitter: jitter,
+				BW:     bw,
+			})
+			if err != nil {
+				return err
+			}
+
+			printApplyResult(cmd, result)
+			return nil
+		},
+	}
+
+	addImpairApplyFlags(cmd, &node, &delay, &loss, &jitter, &bw)
+
+	return cmd
+}
+
+func newLabImpairClearCmd() *cobra.Command {
+	var node string
+
+	cmd := &cobra.Command{
+		Use:   "clear",
+		Short: "Clear impairments from a node",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := lab.Clear(context.Background(), lab.ClearOptions{Node: node})
+			if err != nil {
+				return err
+			}
+
+			status := "absent"
+			if result.Cleared {
+				status = "cleared"
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "cleared node=%s qdisc=%s\n", result.Node, status)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&node, "node", "", "target node")
+	_ = cmd.MarkFlagRequired("node")
+
+	return cmd
+}
+
 func newLabApplyCmd() *cobra.Command {
 	var node string
 	var delay string
@@ -77,33 +151,41 @@ func newLabApplyCmd() *cobra.Command {
 				return err
 			}
 
-			display := func(v string) string {
-				if v == "" {
-					return "-"
-				}
-				return v
-			}
-			fmt.Fprintf(
-				cmd.OutOrStdout(),
-				"applied node=%s delay=%s loss=%s jitter=%s bw=%s\n",
-				result.Node,
-				display(result.Delay),
-				display(result.Loss),
-				display(result.Jitter),
-				display(result.BW),
-			)
+			printApplyResult(cmd, result)
 			return nil
 		},
 	}
 
-	cmd.Flags().StringVar(&node, "node", "", "target node")
-	cmd.Flags().StringVar(&delay, "delay", "", "delay setting")
-	cmd.Flags().StringVar(&loss, "loss", "", "packet loss setting")
-	cmd.Flags().StringVar(&jitter, "jitter", "", "jitter setting")
-	cmd.Flags().StringVar(&bw, "bw", "", "bandwidth setting")
-	_ = cmd.MarkFlagRequired("node")
+	addImpairApplyFlags(cmd, &node, &delay, &loss, &jitter, &bw)
 
 	return cmd
+}
+
+func addImpairApplyFlags(cmd *cobra.Command, node *string, delay *string, loss *string, jitter *string, bw *string) {
+	cmd.Flags().StringVar(node, "node", "", "target node")
+	cmd.Flags().StringVar(delay, "delay", "", "delay setting")
+	cmd.Flags().StringVar(loss, "loss", "", "packet loss setting")
+	cmd.Flags().StringVar(jitter, "jitter", "", "jitter setting")
+	cmd.Flags().StringVar(bw, "bw", "", "bandwidth setting")
+	_ = cmd.MarkFlagRequired("node")
+}
+
+func printApplyResult(cmd *cobra.Command, result *lab.ApplyResult) {
+	display := func(v string) string {
+		if v == "" {
+			return "-"
+		}
+		return v
+	}
+	fmt.Fprintf(
+		cmd.OutOrStdout(),
+		"applied node=%s delay=%s loss=%s jitter=%s bw=%s\n",
+		result.Node,
+		display(result.Delay),
+		display(result.Loss),
+		display(result.Jitter),
+		display(result.BW),
+	)
 }
 
 func newLabShowCmd() *cobra.Command {

--- a/internal/cli/lab_test.go
+++ b/internal/cli/lab_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestLabImpairHelpListsApplyAndClear(t *testing.T) {
+	cmd := newRootCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"lab", "impair", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"Manage node network impairments", "apply", "clear"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected help to contain %q, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestLabImpairApplyRejectsPositionalArgs(t *testing.T) {
+	cmd := newRootCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"lab", "impair", "apply", "--node", "node1", "--bw", "1mbit", "extra"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), `unknown command "extra"`) {
+		t.Fatalf("expected positional arg error, got: %v", err)
+	}
+}
+
+func TestLabImpairClearRejectsPositionalArgs(t *testing.T) {
+	cmd := newRootCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"lab", "impair", "clear", "--node", "node1", "extra"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), `unknown command "extra"`) {
+		t.Fatalf("expected positional arg error, got: %v", err)
+	}
+}

--- a/internal/lab/apply.go
+++ b/internal/lab/apply.go
@@ -39,16 +39,8 @@ func Apply(ctx context.Context, opts ApplyOptions) (*ApplyResult, error) {
 func applyWithDeps(ctx context.Context, opts ApplyOptions, deps createDeps) (*ApplyResult, error) {
 	deps = fillCreateDeps(deps)
 
-	if deps.goos != "linux" {
-		return nil, fmt.Errorf("lab apply is supported only on linux: got %s", deps.goos)
-	}
-	if !deps.isRoot() {
-		return nil, errors.New("lab apply requires root privileges")
-	}
-	for _, cmd := range []string{"ip", "tc"} {
-		if _, err := deps.findPath(cmd); err != nil {
-			return nil, fmt.Errorf("required command %q not found: %w", cmd, err)
-		}
+	if err := validateImpairmentEnvironment(deps, "lab apply"); err != nil {
+		return nil, err
 	}
 
 	opts.Node = strings.TrimSpace(opts.Node)
@@ -105,16 +97,8 @@ func Clear(ctx context.Context, opts ClearOptions) (*ClearResult, error) {
 func clearWithDeps(ctx context.Context, opts ClearOptions, deps createDeps) (*ClearResult, error) {
 	deps = fillCreateDeps(deps)
 
-	if deps.goos != "linux" {
-		return nil, fmt.Errorf("lab impair clear is supported only on linux: got %s", deps.goos)
-	}
-	if !deps.isRoot() {
-		return nil, errors.New("lab impair clear requires root privileges")
-	}
-	for _, cmd := range []string{"ip", "tc"} {
-		if _, err := deps.findPath(cmd); err != nil {
-			return nil, fmt.Errorf("required command %q not found: %w", cmd, err)
-		}
+	if err := validateImpairmentEnvironment(deps, "lab impair clear"); err != nil {
+		return nil, err
 	}
 
 	node, err := validateImpairmentTarget(ctx, deps, opts.Node)
@@ -131,6 +115,21 @@ func clearWithDeps(ctx context.Context, opts ClearOptions, deps createDeps) (*Cl
 	}
 
 	return &ClearResult{Node: node, Cleared: true}, nil
+}
+
+func validateImpairmentEnvironment(deps createDeps, operation string) error {
+	if deps.goos != "linux" {
+		return fmt.Errorf("%s is supported only on linux: got %s", operation, deps.goos)
+	}
+	if !deps.isRoot() {
+		return fmt.Errorf("%s requires root privileges", operation)
+	}
+	for _, cmd := range []string{"ip", "tc"} {
+		if _, err := deps.findPath(cmd); err != nil {
+			return fmt.Errorf("required command %q not found: %w", cmd, err)
+		}
+	}
+	return nil
 }
 
 func validateImpairmentTarget(ctx context.Context, deps createDeps, node string) (string, error) {

--- a/internal/lab/apply.go
+++ b/internal/lab/apply.go
@@ -23,6 +23,15 @@ type ApplyResult struct {
 	BW     string
 }
 
+type ClearOptions struct {
+	Node string
+}
+
+type ClearResult struct {
+	Node    string
+	Cleared bool
+}
+
 func Apply(ctx context.Context, opts ApplyOptions) (*ApplyResult, error) {
 	return applyWithDeps(ctx, opts, defaultCreateDeps())
 }
@@ -53,27 +62,11 @@ func applyWithDeps(ctx context.Context, opts ApplyOptions, deps createDeps) (*Ap
 		return nil, errors.New("jitter requires delay")
 	}
 
-	if deps.loadState == nil {
-		return nil, errors.New("lab state loader is not configured")
-	}
-	state, err := deps.loadState(ctx)
-	if errors.Is(err, ErrStateNotFound) {
-		return nil, errors.New("lab state not found: run `rtc-emulator lab create` first")
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to load lab state: %w", err)
-	}
-	if !containsString(state.Nodes, opts.Node) {
-		return nil, fmt.Errorf("node %q is not managed by current lab", opts.Node)
-	}
-
-	namespaces, err := listNamespaces(ctx, deps.exec)
+	node, err := validateImpairmentTarget(ctx, deps, opts.Node)
 	if err != nil {
 		return nil, err
 	}
-	if !containsString(namespaces, opts.Node) {
-		return nil, fmt.Errorf("node %q namespace not found", opts.Node)
-	}
+	opts.Node = node
 
 	args := []string{
 		"netns", "exec", opts.Node,
@@ -103,6 +96,82 @@ func applyWithDeps(ctx context.Context, opts ApplyOptions, deps createDeps) (*Ap
 		Jitter: opts.Jitter,
 		BW:     opts.BW,
 	}, nil
+}
+
+func Clear(ctx context.Context, opts ClearOptions) (*ClearResult, error) {
+	return clearWithDeps(ctx, opts, defaultCreateDeps())
+}
+
+func clearWithDeps(ctx context.Context, opts ClearOptions, deps createDeps) (*ClearResult, error) {
+	deps = fillCreateDeps(deps)
+
+	if deps.goos != "linux" {
+		return nil, fmt.Errorf("lab impair clear is supported only on linux: got %s", deps.goos)
+	}
+	if !deps.isRoot() {
+		return nil, errors.New("lab impair clear requires root privileges")
+	}
+	for _, cmd := range []string{"ip", "tc"} {
+		if _, err := deps.findPath(cmd); err != nil {
+			return nil, fmt.Errorf("required command %q not found: %w", cmd, err)
+		}
+	}
+
+	node, err := validateImpairmentTarget(ctx, deps, opts.Node)
+	if err != nil {
+		return nil, err
+	}
+
+	err = deps.exec.Run(ctx, "ip", "netns", "exec", node, "tc", "qdisc", "del", "dev", "eth0", "root")
+	if err != nil {
+		if isQdiscMissingError(err) {
+			return &ClearResult{Node: node, Cleared: false}, nil
+		}
+		return nil, fmt.Errorf("failed to clear impairments from %s: %w", node, err)
+	}
+
+	return &ClearResult{Node: node, Cleared: true}, nil
+}
+
+func validateImpairmentTarget(ctx context.Context, deps createDeps, node string) (string, error) {
+	node = strings.TrimSpace(node)
+	if node == "" {
+		return "", errors.New("node is required")
+	}
+
+	if deps.loadState == nil {
+		return "", errors.New("lab state loader is not configured")
+	}
+	state, err := deps.loadState(ctx)
+	if errors.Is(err, ErrStateNotFound) {
+		return "", errors.New("lab state not found: run `rtc-emulator lab create` first")
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to load lab state: %w", err)
+	}
+	if !containsString(state.Nodes, node) {
+		return "", fmt.Errorf("node %q is not managed by current lab", node)
+	}
+
+	namespaces, err := listNamespaces(ctx, deps.exec)
+	if err != nil {
+		return "", err
+	}
+	if !containsString(namespaces, node) {
+		return "", fmt.Errorf("node %q namespace not found", node)
+	}
+
+	return node, nil
+}
+
+func isQdiscMissingError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "no such file or directory") ||
+		strings.Contains(msg, "cannot delete qdisc with handle of zero") ||
+		strings.Contains(msg, "no qdisc")
 }
 
 func containsString(items []string, target string) bool {

--- a/internal/lab/apply.go
+++ b/internal/lab/apply.go
@@ -39,7 +39,7 @@ func Apply(ctx context.Context, opts ApplyOptions) (*ApplyResult, error) {
 func applyWithDeps(ctx context.Context, opts ApplyOptions, deps createDeps) (*ApplyResult, error) {
 	deps = fillCreateDeps(deps)
 
-	if err := validateImpairmentEnvironment(deps, "lab apply"); err != nil {
+	if err := validateImpairmentEnvironment(deps, "lab impairment apply"); err != nil {
 		return nil, err
 	}
 
@@ -168,8 +168,7 @@ func isQdiscMissingError(err error) bool {
 		return false
 	}
 	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "no such file or directory") ||
-		strings.Contains(msg, "cannot delete qdisc with handle of zero") ||
+	return strings.Contains(msg, "cannot delete qdisc with handle of zero") ||
 		strings.Contains(msg, "no qdisc")
 }
 

--- a/internal/lab/apply_test.go
+++ b/internal/lab/apply_test.go
@@ -264,15 +264,9 @@ func TestClearWithDeps_StateNotFound(t *testing.T) {
 	ex := &fakeExecutor{}
 	_, err := clearWithDeps(context.Background(), ClearOptions{
 		Node: "node1",
-	}, createDeps{
-		exec:     ex,
-		goos:     "linux",
-		isRoot:   func() bool { return true },
-		findPath: func(string) (string, error) { return "/bin/x", nil },
-		loadState: func(context.Context) (*LabState, error) {
-			return nil, ErrStateNotFound
-		},
-	})
+	}, impairmentTestDeps(ex, func(context.Context) (*LabState, error) {
+		return nil, ErrStateNotFound
+	}))
 	if err == nil || !strings.Contains(err.Error(), "lab state not found") {
 		t.Fatalf("expected state-not-found error, got: %v", err)
 	}
@@ -282,15 +276,9 @@ func TestClearWithDeps_NodeNotManaged(t *testing.T) {
 	ex := &fakeExecutor{}
 	_, err := clearWithDeps(context.Background(), ClearOptions{
 		Node: "node9",
-	}, createDeps{
-		exec:     ex,
-		goos:     "linux",
-		isRoot:   func() bool { return true },
-		findPath: func(string) (string, error) { return "/bin/x", nil },
-		loadState: func(context.Context) (*LabState, error) {
-			return &LabState{Nodes: []string{"node1", "node2"}}, nil
-		},
-	})
+	}, impairmentTestDeps(ex, func(context.Context) (*LabState, error) {
+		return &LabState{Nodes: []string{"node1", "node2"}}, nil
+	}))
 	if err == nil || !strings.Contains(err.Error(), "is not managed by current lab") {
 		t.Fatalf("expected unmanaged-node error, got: %v", err)
 	}
@@ -307,15 +295,7 @@ func TestClearWithDeps_NodeNamespaceNotFound(t *testing.T) {
 	}
 	_, err := clearWithDeps(context.Background(), ClearOptions{
 		Node: "node1",
-	}, createDeps{
-		exec:     ex,
-		goos:     "linux",
-		isRoot:   func() bool { return true },
-		findPath: func(string) (string, error) { return "/bin/x", nil },
-		loadState: func(context.Context) (*LabState, error) {
-			return &LabState{Nodes: []string{"node1"}}, nil
-		},
-	})
+	}, validImpairmentTestDeps(ex))
 	if err == nil || !strings.Contains(err.Error(), "namespace not found") {
 		t.Fatalf("expected namespace-not-found error, got: %v", err)
 	}
@@ -332,15 +312,7 @@ func TestClearWithDeps_Success(t *testing.T) {
 	}
 	got, err := clearWithDeps(context.Background(), ClearOptions{
 		Node: "node1",
-	}, createDeps{
-		exec:     ex,
-		goos:     "linux",
-		isRoot:   func() bool { return true },
-		findPath: func(string) (string, error) { return "/bin/x", nil },
-		loadState: func(context.Context) (*LabState, error) {
-			return &LabState{Nodes: []string{"node1"}}, nil
-		},
-	})
+	}, validImpairmentTestDeps(ex))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -369,19 +341,27 @@ func TestClearWithDeps_QdiscMissingSucceeds(t *testing.T) {
 	}
 	got, err := clearWithDeps(context.Background(), ClearOptions{
 		Node: "node1",
-	}, createDeps{
-		exec:     ex,
-		goos:     "linux",
-		isRoot:   func() bool { return true },
-		findPath: func(string) (string, error) { return "/bin/x", nil },
-		loadState: func(context.Context) (*LabState, error) {
-			return &LabState{Nodes: []string{"node1"}}, nil
-		},
-	})
+	}, validImpairmentTestDeps(ex))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got.Node != "node1" || got.Cleared {
 		t.Fatalf("expected absent qdisc result, got: %+v", got)
+	}
+}
+
+func validImpairmentTestDeps(ex *fakeExecutor) createDeps {
+	return impairmentTestDeps(ex, func(context.Context) (*LabState, error) {
+		return &LabState{Nodes: []string{"node1"}}, nil
+	})
+}
+
+func impairmentTestDeps(ex *fakeExecutor, loadState func(context.Context) (*LabState, error)) createDeps {
+	return createDeps{
+		exec:      ex,
+		goos:      "linux",
+		isRoot:    func() bool { return true },
+		findPath:  func(string) (string, error) { return "/bin/x", nil },
+		loadState: loadState,
 	}
 }

--- a/internal/lab/apply_test.go
+++ b/internal/lab/apply_test.go
@@ -229,3 +229,159 @@ func TestApplyWithDeps_ReapplyUsesReplace(t *testing.T) {
 		t.Fatalf("missing second replace command, calls=%v", ex.calls)
 	}
 }
+
+func TestClearWithDeps_RequireLinux(t *testing.T) {
+	ex := &fakeExecutor{}
+	_, err := clearWithDeps(context.Background(), ClearOptions{
+		Node: "node1",
+	}, createDeps{
+		exec:     ex,
+		goos:     "darwin",
+		isRoot:   func() bool { return true },
+		findPath: func(string) (string, error) { return "/bin/x", nil },
+	})
+	if err == nil || !strings.Contains(err.Error(), "only on linux") {
+		t.Fatalf("expected linux-only error, got: %v", err)
+	}
+}
+
+func TestClearWithDeps_RequireRoot(t *testing.T) {
+	ex := &fakeExecutor{}
+	_, err := clearWithDeps(context.Background(), ClearOptions{
+		Node: "node1",
+	}, createDeps{
+		exec:     ex,
+		goos:     "linux",
+		isRoot:   func() bool { return false },
+		findPath: func(string) (string, error) { return "/bin/x", nil },
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires root privileges") {
+		t.Fatalf("expected root requirement error, got: %v", err)
+	}
+}
+
+func TestClearWithDeps_StateNotFound(t *testing.T) {
+	ex := &fakeExecutor{}
+	_, err := clearWithDeps(context.Background(), ClearOptions{
+		Node: "node1",
+	}, createDeps{
+		exec:     ex,
+		goos:     "linux",
+		isRoot:   func() bool { return true },
+		findPath: func(string) (string, error) { return "/bin/x", nil },
+		loadState: func(context.Context) (*LabState, error) {
+			return nil, ErrStateNotFound
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "lab state not found") {
+		t.Fatalf("expected state-not-found error, got: %v", err)
+	}
+}
+
+func TestClearWithDeps_NodeNotManaged(t *testing.T) {
+	ex := &fakeExecutor{}
+	_, err := clearWithDeps(context.Background(), ClearOptions{
+		Node: "node9",
+	}, createDeps{
+		exec:     ex,
+		goos:     "linux",
+		isRoot:   func() bool { return true },
+		findPath: func(string) (string, error) { return "/bin/x", nil },
+		loadState: func(context.Context) (*LabState, error) {
+			return &LabState{Nodes: []string{"node1", "node2"}}, nil
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "is not managed by current lab") {
+		t.Fatalf("expected unmanaged-node error, got: %v", err)
+	}
+}
+
+func TestClearWithDeps_NodeNamespaceNotFound(t *testing.T) {
+	ex := &fakeExecutor{
+		outputFn: func(name string, args ...string) (string, error) {
+			if callKey(name, args...) == "ip netns list" {
+				return "node2\n", nil
+			}
+			return "", nil
+		},
+	}
+	_, err := clearWithDeps(context.Background(), ClearOptions{
+		Node: "node1",
+	}, createDeps{
+		exec:     ex,
+		goos:     "linux",
+		isRoot:   func() bool { return true },
+		findPath: func(string) (string, error) { return "/bin/x", nil },
+		loadState: func(context.Context) (*LabState, error) {
+			return &LabState{Nodes: []string{"node1"}}, nil
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "namespace not found") {
+		t.Fatalf("expected namespace-not-found error, got: %v", err)
+	}
+}
+
+func TestClearWithDeps_Success(t *testing.T) {
+	ex := &fakeExecutor{
+		outputFn: func(name string, args ...string) (string, error) {
+			if callKey(name, args...) == "ip netns list" {
+				return "node1\n", nil
+			}
+			return "", nil
+		},
+	}
+	got, err := clearWithDeps(context.Background(), ClearOptions{
+		Node: "node1",
+	}, createDeps{
+		exec:     ex,
+		goos:     "linux",
+		isRoot:   func() bool { return true },
+		findPath: func(string) (string, error) { return "/bin/x", nil },
+		loadState: func(context.Context) (*LabState, error) {
+			return &LabState{Nodes: []string{"node1"}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Node != "node1" || !got.Cleared {
+		t.Fatalf("unexpected result: %+v", got)
+	}
+	if !hasCall(ex.calls, "ip netns exec node1 tc qdisc del dev eth0 root") {
+		t.Fatalf("missing del command, calls=%v", ex.calls)
+	}
+}
+
+func TestClearWithDeps_QdiscMissingSucceeds(t *testing.T) {
+	ex := &fakeExecutor{
+		runFn: func(name string, args ...string) error {
+			if callKey(name, args...) == "ip netns exec node1 tc qdisc del dev eth0 root" {
+				return errors.New("RTNETLINK answers: No such file or directory")
+			}
+			return nil
+		},
+		outputFn: func(name string, args ...string) (string, error) {
+			if callKey(name, args...) == "ip netns list" {
+				return "node1\n", nil
+			}
+			return "", nil
+		},
+	}
+	got, err := clearWithDeps(context.Background(), ClearOptions{
+		Node: "node1",
+	}, createDeps{
+		exec:     ex,
+		goos:     "linux",
+		isRoot:   func() bool { return true },
+		findPath: func(string) (string, error) { return "/bin/x", nil },
+		loadState: func(context.Context) (*LabState, error) {
+			return &LabState{Nodes: []string{"node1"}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Node != "node1" || got.Cleared {
+		t.Fatalf("expected absent qdisc result, got: %+v", got)
+	}
+}

--- a/internal/lab/apply_test.go
+++ b/internal/lab/apply_test.go
@@ -328,7 +328,7 @@ func TestClearWithDeps_QdiscMissingSucceeds(t *testing.T) {
 	ex := &fakeExecutor{
 		runFn: func(name string, args ...string) error {
 			if callKey(name, args...) == "ip netns exec node1 tc qdisc del dev eth0 root" {
-				return errors.New("RTNETLINK answers: No such file or directory")
+				return errors.New("RTNETLINK answers: Cannot delete qdisc with handle of zero")
 			}
 			return nil
 		},
@@ -347,6 +347,29 @@ func TestClearWithDeps_QdiscMissingSucceeds(t *testing.T) {
 	}
 	if got.Node != "node1" || got.Cleared {
 		t.Fatalf("expected absent qdisc result, got: %+v", got)
+	}
+}
+
+func TestClearWithDeps_NamespaceGoneDuringDeleteFails(t *testing.T) {
+	ex := &fakeExecutor{
+		runFn: func(name string, args ...string) error {
+			if callKey(name, args...) == "ip netns exec node1 tc qdisc del dev eth0 root" {
+				return errors.New("Cannot open network namespace \"node1\": No such file or directory")
+			}
+			return nil
+		},
+		outputFn: func(name string, args ...string) (string, error) {
+			if callKey(name, args...) == "ip netns list" {
+				return "node1\n", nil
+			}
+			return "", nil
+		},
+	}
+	_, err := clearWithDeps(context.Background(), ClearOptions{
+		Node: "node1",
+	}, validImpairmentTestDeps(ex))
+	if err == nil || !strings.Contains(err.Error(), "failed to clear impairments from node1") {
+		t.Fatalf("expected namespace delete failure, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `rtc-emulator lab impair apply` as an explicit impairment subcommand while keeping `rtc-emulator lab apply` compatible
- Add `rtc-emulator lab impair clear` to remove node qdisc state
- Share target validation for managed node and namespace checks
- Add fake executor tests for clear success, missing qdisc success, unmanaged nodes, and missing namespaces

## Notes

This is Cycle 1 work for L2 impairment control. It does not add WebRTC scenarios, event logs, or stats logs yet.

Closes #20.

## Validation

- `go test ./...`
- `go run ./cmd/rtc-emulator lab impair --help`
- `go run ./cmd/rtc-emulator lab impair apply --help`
- `go run ./cmd/rtc-emulator lab impair clear --help`

Linux manual testing was not run in this environment.