### PR TITLE
[codex] Save event logs for WebRTC event scenarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 bin/
 .DS_Store
+runs/
+*.log

--- a/internal/cli/lab.go
+++ b/internal/cli/lab.go
@@ -19,6 +19,7 @@ func newLabCmd() *cobra.Command {
 		newLabCreateCmd(),
 		newLabApplyCmd(),
 		newLabImpairCmd(),
+		newLabScenarioCmd(),
 		newLabShowCmd(),
 		newLabDestroyCmd(),
 	)
@@ -127,6 +128,58 @@ func newLabImpairClearCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&node, "node", "", "target node")
 	_ = cmd.MarkFlagRequired("node")
+
+	return cmd
+}
+
+func newLabScenarioCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "scenario",
+		Short: "Run WebRTC-oriented lab scenarios",
+	}
+
+	cmd.AddCommand(newLabScenarioRunCmd())
+
+	return cmd
+}
+
+func newLabScenarioRunCmd() *cobra.Command {
+	var runsDir string
+	var node string
+	var delay string
+	var loss string
+	var jitter string
+	var bw string
+
+	cmd := &cobra.Command{
+		Use:   "run SCENARIO",
+		Short: "Run a named lab scenario and save event logs",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := lab.RunScenario(context.Background(), lab.ScenarioRunOptions{
+				Scenario: args[0],
+				RunsDir:  runsDir,
+				Node:     node,
+				Delay:    delay,
+				Loss:     loss,
+				Jitter:   jitter,
+				BW:       bw,
+			})
+			if result != nil {
+				fmt.Fprintf(cmd.OutOrStdout(), "run-id=%s\n", result.RunID)
+				fmt.Fprintf(cmd.OutOrStdout(), "run-dir=%s\n", result.RunDir)
+				fmt.Fprintf(cmd.OutOrStdout(), "events=%s\n", result.EventsPath)
+			}
+			return err
+		},
+	}
+
+	cmd.Flags().StringVar(&runsDir, "runs-dir", "runs", "directory for scenario run outputs")
+	cmd.Flags().StringVar(&node, "node", "node1", "target node")
+	cmd.Flags().StringVar(&delay, "delay", "", "delay setting")
+	cmd.Flags().StringVar(&loss, "loss", "", "packet loss setting")
+	cmd.Flags().StringVar(&jitter, "jitter", "", "jitter setting")
+	cmd.Flags().StringVar(&bw, "bw", "", "bandwidth setting")
 
 	return cmd
 }

--- a/internal/cli/lab_test.go
+++ b/internal/cli/lab_test.go
@@ -24,6 +24,24 @@ func TestLabImpairHelpListsApplyAndClear(t *testing.T) {
 	}
 }
 
+func TestLabScenarioRunHelpListsBuiltInScenarioOptions(t *testing.T) {
+	cmd := newRootCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"lab", "scenario", "run", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"Run a named lab scenario", "--runs-dir", "--node", "--bw"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected help to contain %q, got:\n%s", want, got)
+		}
+	}
+}
+
 func TestLabImpairApplyRejectsPositionalArgs(t *testing.T) {
 	cmd := newRootCmd()
 	var out bytes.Buffer

--- a/internal/lab/eventlog.go
+++ b/internal/lab/eventlog.go
@@ -1,0 +1,90 @@
+package lab
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type EventRecord struct {
+	RunID     string              `json:"run_id"`
+	Event     string              `json:"event"`
+	Scenario  string              `json:"scenario"`
+	Phase     string              `json:"phase"`
+	Time      string              `json:"time"`
+	Node      string              `json:"node"`
+	Interface string              `json:"interface"`
+	Action    string              `json:"action"`
+	Condition ImpairmentCondition `json:"condition"`
+	Status    string              `json:"status"`
+	Error     string              `json:"error"`
+}
+
+type ImpairmentCondition struct {
+	Delay  string `json:"delay"`
+	Loss   string `json:"loss"`
+	Jitter string `json:"jitter"`
+	BW     string `json:"bw"`
+}
+
+type eventLogger struct {
+	runID      string
+	runDir     string
+	eventsPath string
+	writer     io.WriteCloser
+}
+
+func generateRunID(t time.Time) (string, error) {
+	var suffix [4]byte
+	if _, err := rand.Read(suffix[:]); err != nil {
+		return "", err
+	}
+	return t.UTC().Format("20060102T150405.000000000Z") + "-" + hex.EncodeToString(suffix[:]), nil
+}
+
+func newEventLogger(runsDir string, runID string, deps scenarioRunDeps) (*eventLogger, error) {
+	runDir := filepath.Join(runsDir, runID)
+	if err := deps.mkdirAll(runDir, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create run directory %s: %w", runDir, err)
+	}
+
+	eventsPath := filepath.Join(runDir, "events.jsonl")
+	writer, err := deps.openFile(eventsPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open event log %s: %w", eventsPath, err)
+	}
+
+	return &eventLogger{
+		runID:      runID,
+		runDir:     runDir,
+		eventsPath: eventsPath,
+		writer:     writer,
+	}, nil
+}
+
+func (l *eventLogger) write(record EventRecord) error {
+	b, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("failed to encode event record: %w", err)
+	}
+	if _, err := l.writer.Write(append(b, '\n')); err != nil {
+		return fmt.Errorf("failed to write event log %s: %w", l.eventsPath, err)
+	}
+	return nil
+}
+
+func (l *eventLogger) close() error {
+	if l.writer == nil {
+		return nil
+	}
+	if err := l.writer.Close(); err != nil {
+		return fmt.Errorf("failed to close event log %s: %w", l.eventsPath, err)
+	}
+	l.writer = nil
+	return nil
+}

--- a/internal/lab/scenario.go
+++ b/internal/lab/scenario.go
@@ -1,0 +1,308 @@
+package lab
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	ScenarioWebRTCUplinkCongestion = "webrtc-uplink-congestion"
+
+	defaultRunsDir       = "runs"
+	defaultScenarioNode  = "node1"
+	defaultScenarioIface = "eth0"
+	defaultUplinkBW      = "1mbit"
+)
+
+type ScenarioRunOptions struct {
+	Scenario  string
+	RunsDir   string
+	Node      string
+	Interface string
+	Delay     string
+	Loss      string
+	Jitter    string
+	BW        string
+}
+
+type ScenarioRunResult struct {
+	RunID      string
+	RunDir     string
+	EventsPath string
+}
+
+type EventRecord struct {
+	RunID     string              `json:"run_id"`
+	Event     string              `json:"event"`
+	Scenario  string              `json:"scenario"`
+	Phase     string              `json:"phase"`
+	Time      string              `json:"time"`
+	Node      string              `json:"node"`
+	Interface string              `json:"interface"`
+	Action    string              `json:"action"`
+	Condition ImpairmentCondition `json:"condition"`
+	Status    string              `json:"status"`
+	Error     string              `json:"error"`
+}
+
+type ImpairmentCondition struct {
+	Delay  string `json:"delay"`
+	Loss   string `json:"loss"`
+	Jitter string `json:"jitter"`
+	BW     string `json:"bw"`
+}
+
+type scenarioRunDeps struct {
+	now      func() time.Time
+	newRunID func(time.Time) (string, error)
+	mkdirAll func(string, os.FileMode) error
+	openFile func(string, int, os.FileMode) (io.WriteCloser, error)
+}
+
+type eventLogger struct {
+	runID      string
+	runDir     string
+	eventsPath string
+	writer     io.WriteCloser
+}
+
+func RunScenario(ctx context.Context, opts ScenarioRunOptions) (*ScenarioRunResult, error) {
+	return runScenarioWithDeps(ctx, opts, defaultCreateDeps(), scenarioRunDeps{})
+}
+
+func runScenarioWithDeps(
+	ctx context.Context,
+	opts ScenarioRunOptions,
+	deps createDeps,
+	runDeps scenarioRunDeps,
+) (*ScenarioRunResult, error) {
+	opts = normalizeScenarioRunOptions(opts)
+	deps = fillCreateDeps(deps)
+	runDeps = fillScenarioRunDeps(runDeps)
+
+	if err := validateScenarioRunOptions(opts); err != nil {
+		return nil, err
+	}
+
+	startedAt := runDeps.now().UTC()
+	runID, err := runDeps.newRunID(startedAt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate run id: %w", err)
+	}
+
+	logger, err := newEventLogger(opts.RunsDir, runID, runDeps)
+	if err != nil {
+		return nil, err
+	}
+	result := &ScenarioRunResult{
+		RunID:      logger.runID,
+		RunDir:     logger.runDir,
+		EventsPath: logger.eventsPath,
+	}
+
+	condition := ImpairmentCondition{
+		Delay:  opts.Delay,
+		Loss:   opts.Loss,
+		Jitter: opts.Jitter,
+		BW:     opts.BW,
+	}
+
+	record := func(phase string, action string, status string, opErr error) error {
+		return logger.write(EventRecord{
+			RunID:     runID,
+			Event:     "scenario_phase",
+			Scenario:  opts.Scenario,
+			Phase:     phase,
+			Time:      runDeps.now().UTC().Format(time.RFC3339Nano),
+			Node:      opts.Node,
+			Interface: opts.Interface,
+			Action:    action,
+			Condition: condition,
+			Status:    status,
+			Error:     errorString(opErr),
+		})
+	}
+
+	var runErr error
+	if err := record("baseline", "start", "ok", nil); err != nil {
+		return result, errors.Join(err, logger.close())
+	}
+
+	_, applyErr := applyWithDeps(ctx, ApplyOptions{
+		Node:   opts.Node,
+		Delay:  opts.Delay,
+		Loss:   opts.Loss,
+		Jitter: opts.Jitter,
+		BW:     opts.BW,
+	}, deps)
+	if applyErr != nil {
+		runErr = errors.Join(runErr, fmt.Errorf("impaired phase failed: %w", applyErr))
+	}
+	if err := record("impaired", "apply", statusForError(applyErr), applyErr); err != nil {
+		runErr = errors.Join(runErr, err)
+	}
+
+	if applyErr == nil {
+		recoveryResult, recoveryErr := clearWithDeps(ctx, ClearOptions{Node: opts.Node}, deps)
+		if recoveryErr != nil {
+			runErr = errors.Join(runErr, fmt.Errorf("recovery phase failed: %w", recoveryErr))
+		}
+		if err := record("recovery", "clear", statusForClear(recoveryResult, recoveryErr), recoveryErr); err != nil {
+			runErr = errors.Join(runErr, err)
+		}
+	} else if err := record("recovery", "skip", "skipped", nil); err != nil {
+		runErr = errors.Join(runErr, err)
+	}
+
+	cleanupResult, cleanupErr := clearWithDeps(ctx, ClearOptions{Node: opts.Node}, deps)
+	if cleanupErr != nil {
+		runErr = errors.Join(runErr, fmt.Errorf("cleanup phase failed: %w", cleanupErr))
+	}
+	if err := record("cleanup", "clear", statusForClear(cleanupResult, cleanupErr), cleanupErr); err != nil {
+		runErr = errors.Join(runErr, err)
+	}
+	if err := logger.close(); err != nil {
+		runErr = errors.Join(runErr, err)
+	}
+
+	return result, runErr
+}
+
+func normalizeScenarioRunOptions(opts ScenarioRunOptions) ScenarioRunOptions {
+	opts.Scenario = strings.TrimSpace(opts.Scenario)
+	opts.RunsDir = strings.TrimSpace(opts.RunsDir)
+	opts.Node = strings.TrimSpace(opts.Node)
+	opts.Interface = strings.TrimSpace(opts.Interface)
+	opts.Delay = strings.TrimSpace(opts.Delay)
+	opts.Loss = strings.TrimSpace(opts.Loss)
+	opts.Jitter = strings.TrimSpace(opts.Jitter)
+	opts.BW = strings.TrimSpace(opts.BW)
+
+	if opts.RunsDir == "" {
+		opts.RunsDir = defaultRunsDir
+	}
+	if opts.Node == "" {
+		opts.Node = defaultScenarioNode
+	}
+	if opts.Interface == "" {
+		opts.Interface = defaultScenarioIface
+	}
+	if opts.Scenario == ScenarioWebRTCUplinkCongestion && opts.Delay == "" && opts.Loss == "" && opts.BW == "" {
+		opts.BW = defaultUplinkBW
+	}
+	return opts
+}
+
+func validateScenarioRunOptions(opts ScenarioRunOptions) error {
+	if opts.Scenario != ScenarioWebRTCUplinkCongestion {
+		return fmt.Errorf("unsupported scenario %q", opts.Scenario)
+	}
+	if opts.Jitter != "" && opts.Delay == "" {
+		return errors.New("jitter requires delay")
+	}
+	if opts.Delay == "" && opts.Loss == "" && opts.BW == "" {
+		return errors.New("at least one impairment condition is required")
+	}
+	return nil
+}
+
+func fillScenarioRunDeps(deps scenarioRunDeps) scenarioRunDeps {
+	if deps.now == nil {
+		deps.now = time.Now
+	}
+	if deps.newRunID == nil {
+		deps.newRunID = generateRunID
+	}
+	if deps.mkdirAll == nil {
+		deps.mkdirAll = os.MkdirAll
+	}
+	if deps.openFile == nil {
+		deps.openFile = func(path string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+			return os.OpenFile(path, flag, perm)
+		}
+	}
+	return deps
+}
+
+func generateRunID(t time.Time) (string, error) {
+	var suffix [4]byte
+	if _, err := rand.Read(suffix[:]); err != nil {
+		return "", err
+	}
+	return t.UTC().Format("20060102T150405.000000000Z") + "-" + hex.EncodeToString(suffix[:]), nil
+}
+
+func newEventLogger(runsDir string, runID string, deps scenarioRunDeps) (*eventLogger, error) {
+	runDir := filepath.Join(runsDir, runID)
+	if err := deps.mkdirAll(runDir, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create run directory %s: %w", runDir, err)
+	}
+
+	eventsPath := filepath.Join(runDir, "events.jsonl")
+	writer, err := deps.openFile(eventsPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open event log %s: %w", eventsPath, err)
+	}
+
+	return &eventLogger{
+		runID:      runID,
+		runDir:     runDir,
+		eventsPath: eventsPath,
+		writer:     writer,
+	}, nil
+}
+
+func (l *eventLogger) write(record EventRecord) error {
+	b, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("failed to encode event record: %w", err)
+	}
+	if _, err := l.writer.Write(append(b, '\n')); err != nil {
+		return fmt.Errorf("failed to write event log %s: %w", l.eventsPath, err)
+	}
+	return nil
+}
+
+func (l *eventLogger) close() error {
+	if l.writer == nil {
+		return nil
+	}
+	if err := l.writer.Close(); err != nil {
+		return fmt.Errorf("failed to close event log %s: %w", l.eventsPath, err)
+	}
+	l.writer = nil
+	return nil
+}
+
+func statusForError(err error) string {
+	if err != nil {
+		return "error"
+	}
+	return "ok"
+}
+
+func statusForClear(result *ClearResult, err error) string {
+	if err != nil {
+		return "error"
+	}
+	if result != nil && !result.Cleared {
+		return "absent"
+	}
+	return "cleared"
+}
+
+func errorString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/internal/lab/scenario.go
+++ b/internal/lab/scenario.go
@@ -2,14 +2,10 @@ package lab
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 )
@@ -40,39 +36,11 @@ type ScenarioRunResult struct {
 	EventsPath string
 }
 
-type EventRecord struct {
-	RunID     string              `json:"run_id"`
-	Event     string              `json:"event"`
-	Scenario  string              `json:"scenario"`
-	Phase     string              `json:"phase"`
-	Time      string              `json:"time"`
-	Node      string              `json:"node"`
-	Interface string              `json:"interface"`
-	Action    string              `json:"action"`
-	Condition ImpairmentCondition `json:"condition"`
-	Status    string              `json:"status"`
-	Error     string              `json:"error"`
-}
-
-type ImpairmentCondition struct {
-	Delay  string `json:"delay"`
-	Loss   string `json:"loss"`
-	Jitter string `json:"jitter"`
-	BW     string `json:"bw"`
-}
-
 type scenarioRunDeps struct {
 	now      func() time.Time
 	newRunID func(time.Time) (string, error)
 	mkdirAll func(string, os.FileMode) error
 	openFile func(string, int, os.FileMode) (io.WriteCloser, error)
-}
-
-type eventLogger struct {
-	runID      string
-	runDir     string
-	eventsPath string
-	writer     io.WriteCloser
 }
 
 func RunScenario(ctx context.Context, opts ScenarioRunOptions) (*ScenarioRunResult, error) {
@@ -231,56 +199,6 @@ func fillScenarioRunDeps(deps scenarioRunDeps) scenarioRunDeps {
 		}
 	}
 	return deps
-}
-
-func generateRunID(t time.Time) (string, error) {
-	var suffix [4]byte
-	if _, err := rand.Read(suffix[:]); err != nil {
-		return "", err
-	}
-	return t.UTC().Format("20060102T150405.000000000Z") + "-" + hex.EncodeToString(suffix[:]), nil
-}
-
-func newEventLogger(runsDir string, runID string, deps scenarioRunDeps) (*eventLogger, error) {
-	runDir := filepath.Join(runsDir, runID)
-	if err := deps.mkdirAll(runDir, 0o755); err != nil {
-		return nil, fmt.Errorf("failed to create run directory %s: %w", runDir, err)
-	}
-
-	eventsPath := filepath.Join(runDir, "events.jsonl")
-	writer, err := deps.openFile(eventsPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open event log %s: %w", eventsPath, err)
-	}
-
-	return &eventLogger{
-		runID:      runID,
-		runDir:     runDir,
-		eventsPath: eventsPath,
-		writer:     writer,
-	}, nil
-}
-
-func (l *eventLogger) write(record EventRecord) error {
-	b, err := json.Marshal(record)
-	if err != nil {
-		return fmt.Errorf("failed to encode event record: %w", err)
-	}
-	if _, err := l.writer.Write(append(b, '\n')); err != nil {
-		return fmt.Errorf("failed to write event log %s: %w", l.eventsPath, err)
-	}
-	return nil
-}
-
-func (l *eventLogger) close() error {
-	if l.writer == nil {
-		return nil
-	}
-	if err := l.writer.Close(); err != nil {
-		return fmt.Errorf("failed to close event log %s: %w", l.eventsPath, err)
-	}
-	l.writer = nil
-	return nil
 }
 
 func statusForError(err error) string {

--- a/internal/lab/scenario.go
+++ b/internal/lab/scenario.go
@@ -174,6 +174,9 @@ func validateScenarioRunOptions(opts ScenarioRunOptions) error {
 	if opts.Scenario != ScenarioWebRTCUplinkCongestion {
 		return fmt.Errorf("unsupported scenario %q", opts.Scenario)
 	}
+	if opts.Interface != defaultScenarioIface {
+		return fmt.Errorf("unsupported interface %q: only %s is supported", opts.Interface, defaultScenarioIface)
+	}
 	if opts.Jitter != "" && opts.Delay == "" {
 		return errors.New("jitter requires delay")
 	}

--- a/internal/lab/scenario_test.go
+++ b/internal/lab/scenario_test.go
@@ -88,6 +88,34 @@ func TestRunScenarioWithDeps_ApplyFailureStillLogsCleanup(t *testing.T) {
 	}
 }
 
+func TestRunScenarioWithDeps_RejectsUnsupportedInterface(t *testing.T) {
+	ex := scenarioTestExecutor(nil)
+	runsDir := filepath.Join(t.TempDir(), "runs")
+
+	got, err := runScenarioWithDeps(
+		context.Background(),
+		ScenarioRunOptions{
+			Scenario:  ScenarioWebRTCUplinkCongestion,
+			RunsDir:   runsDir,
+			Interface: "eth1",
+		},
+		validImpairmentTestDeps(ex),
+		fixedScenarioRunDeps("run-unsupported-interface"),
+	)
+	if err == nil || !strings.Contains(err.Error(), `unsupported interface "eth1"`) {
+		t.Fatalf("expected unsupported interface error, got: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil result, got: %+v", got)
+	}
+	if len(ex.calls) != 0 {
+		t.Fatalf("expected no apply or clear calls, got: %v", ex.calls)
+	}
+	if _, statErr := os.Stat(filepath.Join(runsDir, "run-unsupported-interface")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected no run directory, stat err: %v", statErr)
+	}
+}
+
 func TestRunScenarioWithDeps_ClearFailureLoggedAsError(t *testing.T) {
 	ex := scenarioTestExecutor(func(name string, args ...string) error {
 		if callKey(name, args...) == "ip netns exec node1 tc qdisc del dev eth0 root" {

--- a/internal/lab/scenario_test.go
+++ b/internal/lab/scenario_test.go
@@ -1,0 +1,236 @@
+package lab
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunScenarioWithDeps_WritesJSONLAndPhaseOrder(t *testing.T) {
+	ex := scenarioTestExecutor(nil)
+	runsDir := filepath.Join(t.TempDir(), "runs")
+
+	got, err := runScenarioWithDeps(
+		context.Background(),
+		ScenarioRunOptions{Scenario: ScenarioWebRTCUplinkCongestion, RunsDir: runsDir},
+		validImpairmentTestDeps(ex),
+		fixedScenarioRunDeps("run-test"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.RunID != "run-test" {
+		t.Fatalf("unexpected run id: %s", got.RunID)
+	}
+	if got.EventsPath != filepath.Join(runsDir, "run-test", "events.jsonl") {
+		t.Fatalf("unexpected events path: %s", got.EventsPath)
+	}
+
+	events := readScenarioEvents(t, got.EventsPath)
+	assertPhases(t, events, []string{"baseline", "impaired", "recovery", "cleanup"})
+	for _, event := range events {
+		if event.RunID != "run-test" {
+			t.Fatalf("unexpected run id in event: %+v", event)
+		}
+		if event.Scenario != ScenarioWebRTCUplinkCongestion {
+			t.Fatalf("unexpected scenario in event: %+v", event)
+		}
+		if event.Condition.BW != defaultUplinkBW {
+			t.Fatalf("expected default bw %s, got %+v", defaultUplinkBW, event.Condition)
+		}
+	}
+	if !hasCall(ex.calls, "ip netns exec node1 tc qdisc replace dev eth0 root netem rate 1mbit") {
+		t.Fatalf("missing apply command, calls=%v", ex.calls)
+	}
+	if countCall(ex.calls, "ip netns exec node1 tc qdisc del dev eth0 root") != 2 {
+		t.Fatalf("expected recovery and cleanup clear calls, calls=%v", ex.calls)
+	}
+}
+
+func TestRunScenarioWithDeps_ApplyFailureStillLogsCleanup(t *testing.T) {
+	ex := scenarioTestExecutor(func(name string, args ...string) error {
+		if callKey(name, args...) == "ip netns exec node1 tc qdisc replace dev eth0 root netem rate 1mbit" {
+			return errors.New("apply failed")
+		}
+		return nil
+	})
+	runsDir := filepath.Join(t.TempDir(), "runs")
+
+	got, err := runScenarioWithDeps(
+		context.Background(),
+		ScenarioRunOptions{Scenario: ScenarioWebRTCUplinkCongestion, RunsDir: runsDir},
+		validImpairmentTestDeps(ex),
+		fixedScenarioRunDeps("run-apply-failure"),
+	)
+	if err == nil || !strings.Contains(err.Error(), "impaired phase failed") {
+		t.Fatalf("expected impaired phase error, got: %v", err)
+	}
+
+	events := readScenarioEvents(t, got.EventsPath)
+	assertPhases(t, events, []string{"baseline", "impaired", "recovery", "cleanup"})
+	if events[1].Status != "error" || !strings.Contains(events[1].Error, "apply failed") {
+		t.Fatalf("expected impaired error event, got: %+v", events[1])
+	}
+	if events[2].Status != "skipped" {
+		t.Fatalf("expected skipped recovery after apply failure, got: %+v", events[2])
+	}
+	if events[3].Phase != "cleanup" || events[3].Status == "skipped" {
+		t.Fatalf("expected cleanup result, got: %+v", events[3])
+	}
+	if countCall(ex.calls, "ip netns exec node1 tc qdisc del dev eth0 root") != 1 {
+		t.Fatalf("expected cleanup clear call, calls=%v", ex.calls)
+	}
+}
+
+func TestRunScenarioWithDeps_ClearFailureLoggedAsError(t *testing.T) {
+	ex := scenarioTestExecutor(func(name string, args ...string) error {
+		if callKey(name, args...) == "ip netns exec node1 tc qdisc del dev eth0 root" {
+			return errors.New("clear failed")
+		}
+		return nil
+	})
+	runsDir := filepath.Join(t.TempDir(), "runs")
+
+	got, err := runScenarioWithDeps(
+		context.Background(),
+		ScenarioRunOptions{Scenario: ScenarioWebRTCUplinkCongestion, RunsDir: runsDir},
+		validImpairmentTestDeps(ex),
+		fixedScenarioRunDeps("run-clear-failure"),
+	)
+	if err == nil || !strings.Contains(err.Error(), "recovery phase failed") || !strings.Contains(err.Error(), "cleanup phase failed") {
+		t.Fatalf("expected recovery and cleanup errors, got: %v", err)
+	}
+
+	events := readScenarioEvents(t, got.EventsPath)
+	assertPhases(t, events, []string{"baseline", "impaired", "recovery", "cleanup"})
+	if events[2].Status != "error" || !strings.Contains(events[2].Error, "clear failed") {
+		t.Fatalf("expected recovery error event, got: %+v", events[2])
+	}
+	if events[3].Status != "error" || !strings.Contains(events[3].Error, "clear failed") {
+		t.Fatalf("expected cleanup error event, got: %+v", events[3])
+	}
+}
+
+func TestRunScenarioWithDeps_LogWriteFailureReturnsErrorAndCleansUp(t *testing.T) {
+	ex := scenarioTestExecutor(nil)
+	writer := &failingWriteCloser{failOn: 2}
+
+	_, err := runScenarioWithDeps(
+		context.Background(),
+		ScenarioRunOptions{Scenario: ScenarioWebRTCUplinkCongestion, RunsDir: "runs"},
+		validImpairmentTestDeps(ex),
+		scenarioRunDeps{
+			now: func() time.Time {
+				return time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+			},
+			newRunID: func(time.Time) (string, error) {
+				return "run-write-failure", nil
+			},
+			mkdirAll: func(string, os.FileMode) error {
+				return nil
+			},
+			openFile: func(string, int, os.FileMode) (io.WriteCloser, error) {
+				return writer, nil
+			},
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "failed to write event log") {
+		t.Fatalf("expected log write error, got: %v", err)
+	}
+	if !writer.closed {
+		t.Fatalf("expected writer to be closed")
+	}
+	if countCall(ex.calls, "ip netns exec node1 tc qdisc del dev eth0 root") != 2 {
+		t.Fatalf("expected recovery and cleanup despite log write failure, calls=%v", ex.calls)
+	}
+}
+
+func scenarioTestExecutor(runFn func(name string, args ...string) error) *fakeExecutor {
+	return &fakeExecutor{
+		runFn: runFn,
+		outputFn: func(name string, args ...string) (string, error) {
+			if callKey(name, args...) == "ip netns list" {
+				return "node1\n", nil
+			}
+			return "", nil
+		},
+	}
+}
+
+func fixedScenarioRunDeps(runID string) scenarioRunDeps {
+	return scenarioRunDeps{
+		now: func() time.Time {
+			return time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+		},
+		newRunID: func(time.Time) (string, error) {
+			return runID, nil
+		},
+	}
+}
+
+func readScenarioEvents(t *testing.T, path string) []EventRecord {
+	t.Helper()
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read events: %v", err)
+	}
+	rawLines := strings.Split(strings.TrimSpace(string(b)), "\n")
+	events := make([]EventRecord, 0, len(rawLines))
+	for _, line := range rawLines {
+		var event EventRecord
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("failed to parse event line %q: %v", line, err)
+		}
+		events = append(events, event)
+	}
+	return events
+}
+
+func assertPhases(t *testing.T, events []EventRecord, want []string) {
+	t.Helper()
+
+	if len(events) != len(want) {
+		t.Fatalf("expected %d events, got %d: %+v", len(want), len(events), events)
+	}
+	for i, phase := range want {
+		if events[i].Phase != phase {
+			t.Fatalf("event %d phase: want %s, got %+v", i, phase, events[i])
+		}
+	}
+}
+
+func countCall(calls []string, want string) int {
+	count := 0
+	for _, c := range calls {
+		if c == want {
+			count++
+		}
+	}
+	return count
+}
+
+type failingWriteCloser struct {
+	failOn int
+	writes int
+	closed bool
+}
+
+func (w *failingWriteCloser) Write(p []byte) (int, error) {
+	w.writes++
+	if w.writes == w.failOn {
+		return 0, errors.New("write failed")
+	}
+	return len(p), nil
+}
+
+func (w *failingWriteCloser) Close() error {
+	w.closed = true
+	return nil
+}


### PR DESCRIPTION
## Summary

- Add `lab scenario run webrtc-uplink-congestion` as the first scenario-style run command.
- Generate per-run directories under `runs/<run-id>/` and write one JSON event per line to `events.jsonl`.
- Record baseline, impaired, recovery, and cleanup phases, including cleanup results after apply failures.
- Cover successful logging, phase ordering, apply failure cleanup, clear failure logging, and log write failures with unit tests.

Closes #24

## Validation

- `go test ./...`
- `go run ./cmd/rtc-emulator lab scenario run webrtc-uplink-congestion --help`