### PR TITLE
Cycle 4: Connect webrtc-uplink-congestion end to end

### DIFF
--- a/examples/pion/01-p2p-operations.md
+++ b/examples/pion/01-p2p-operations.md
@@ -88,3 +88,54 @@ Confirm no leftovers:
 sudo ip netns list
 sudo ip link show rtcemu0
 ```
+
+## 6. Run the uplink congestion scenario
+
+Create a fresh 2-node lab, then run the named end-to-end scenario:
+
+```bash
+sudo ./bin/rtc-emulator lab create --nodes 2
+
+sudo ./bin/rtc-emulator lab scenario run webrtc-uplink-congestion \
+  --node node1 \
+  --peer node2 \
+  --bw 1mbit \
+  --baseline 5s \
+  --impaired 10s \
+  --recovery 5s \
+  --stats-interval 1s
+```
+
+Expected output:
+
+```text
+run-id=<run-id>
+run-dir=runs/<run-id>
+latest-dir=runs/latest
+events=runs/<run-id>/events.jsonl
+stats=runs/<run-id>/stats.jsonl
+```
+
+Check the phase window:
+
+```bash
+jq -r '.time + " " + .phase + " " + .status + " " + (.condition.bw // "")' runs/latest/events.jsonl
+```
+
+Check WebRTC-side counters near that window:
+
+```bash
+jq -r 'select(.node=="node1") | [.time,.bytes_sent,.data_messages_sent] | @tsv' runs/latest/stats.jsonl
+```
+
+Check cleanup state:
+
+```bash
+sudo ip netns exec node1 tc qdisc show dev eth0
+```
+
+Manual verification notes:
+
+- `impaired` should show `1mbit` for `node1`.
+- `cleanup` should leave no managed qdisc behind on `node1`.
+- compare `node1` `bytes_sent` deltas before, during, and after the impaired window; this DataChannel-only runner does not produce video frame counters.

--- a/internal/cli/lab.go
+++ b/internal/cli/lab.go
@@ -148,10 +148,15 @@ func newLabScenarioCmd() *cobra.Command {
 func newLabScenarioRunCmd() *cobra.Command {
 	var runsDir string
 	var node string
+	var peer string
 	var delay string
 	var loss string
 	var jitter string
 	var bw string
+	var baseline time.Duration
+	var impaired time.Duration
+	var recovery time.Duration
+	var statsInterval time.Duration
 
 	cmd := &cobra.Command{
 		Use:   "run SCENARIO",
@@ -159,18 +164,21 @@ func newLabScenarioRunCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			result, err := lab.RunScenario(context.Background(), lab.ScenarioRunOptions{
-				Scenario: args[0],
-				RunsDir:  runsDir,
-				Node:     node,
-				Delay:    delay,
-				Loss:     loss,
-				Jitter:   jitter,
-				BW:       bw,
+				Scenario:         args[0],
+				RunsDir:          runsDir,
+				Node:             node,
+				Peer:             peer,
+				Delay:            delay,
+				Loss:             loss,
+				Jitter:           jitter,
+				BW:               bw,
+				BaselineDuration: baseline,
+				ImpairedDuration: impaired,
+				RecoveryDuration: recovery,
+				StatsInterval:    statsInterval,
 			})
 			if result != nil {
-				fmt.Fprintf(cmd.OutOrStdout(), "run-id=%s\n", result.RunID)
-				fmt.Fprintf(cmd.OutOrStdout(), "run-dir=%s\n", result.RunDir)
-				fmt.Fprintf(cmd.OutOrStdout(), "events=%s\n", result.EventsPath)
+				printScenarioRunResult(cmd, result)
 			}
 			return err
 		},
@@ -178,12 +186,25 @@ func newLabScenarioRunCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&runsDir, "runs-dir", "runs", "directory for scenario run outputs")
 	cmd.Flags().StringVar(&node, "node", "node1", "target node")
+	cmd.Flags().StringVar(&peer, "peer", "node2", "WebRTC peer node")
 	cmd.Flags().StringVar(&delay, "delay", "", "delay setting")
 	cmd.Flags().StringVar(&loss, "loss", "", "packet loss setting")
 	cmd.Flags().StringVar(&jitter, "jitter", "", "jitter setting")
 	cmd.Flags().StringVar(&bw, "bw", "", "bandwidth setting")
+	cmd.Flags().DurationVar(&baseline, "baseline", 5*time.Second, "baseline phase duration")
+	cmd.Flags().DurationVar(&impaired, "impaired", 10*time.Second, "impaired phase duration")
+	cmd.Flags().DurationVar(&recovery, "recovery", 5*time.Second, "recovery phase duration")
+	cmd.Flags().DurationVar(&statsInterval, "stats-interval", time.Second, "stats collection interval")
 
 	return cmd
+}
+
+func printScenarioRunResult(cmd *cobra.Command, result *lab.ScenarioRunResult) {
+	fmt.Fprintf(cmd.OutOrStdout(), "run-id=%s\n", result.RunID)
+	fmt.Fprintf(cmd.OutOrStdout(), "run-dir=%s\n", result.RunDir)
+	fmt.Fprintf(cmd.OutOrStdout(), "latest-dir=%s\n", result.LatestDir)
+	fmt.Fprintf(cmd.OutOrStdout(), "events=%s\n", result.EventsPath)
+	fmt.Fprintf(cmd.OutOrStdout(), "stats=%s\n", result.StatsPath)
 }
 
 func newLabWebRTCCmd() *cobra.Command {

--- a/internal/cli/lab_test.go
+++ b/internal/cli/lab_test.go
@@ -38,7 +38,17 @@ func TestLabScenarioRunHelpListsBuiltInScenarioOptions(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	got := out.String()
-	for _, want := range []string{"Run a named lab scenario", "--runs-dir", "--node", "--bw"} {
+	for _, want := range []string{
+		"Run a named lab scenario",
+		"--runs-dir",
+		"--node",
+		"--peer",
+		"--bw",
+		"--baseline",
+		"--impaired",
+		"--recovery",
+		"--stats-interval",
+	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("expected help to contain %q, got:\n%s", want, got)
 		}
@@ -86,6 +96,33 @@ func TestLabWebRTCHelpHidesInternalPeerCommand(t *testing.T) {
 	}
 	if !strings.Contains(got, "p2p") {
 		t.Fatalf("expected help to expose p2p command, got:\n%s", got)
+	}
+}
+
+func TestPrintScenarioRunResultIncludesStatsAndLatestDir(t *testing.T) {
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	printScenarioRunResult(cmd, &lab.ScenarioRunResult{
+		RunID:      "run-1",
+		RunDir:     "runs/run-1",
+		LatestDir:  "runs/latest",
+		EventsPath: "runs/run-1/events.jsonl",
+		StatsPath:  "runs/run-1/stats.jsonl",
+	})
+
+	got := out.String()
+	for _, want := range []string{
+		"run-id=run-1\n",
+		"run-dir=runs/run-1\n",
+		"latest-dir=runs/latest\n",
+		"events=runs/run-1/events.jsonl\n",
+		"stats=runs/run-1/stats.jsonl\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected output to contain %q, got:\n%s", want, got)
+		}
 	}
 }
 

--- a/internal/lab/apply_test.go
+++ b/internal/lab/apply_test.go
@@ -375,7 +375,7 @@ func TestClearWithDeps_NamespaceGoneDuringDeleteFails(t *testing.T) {
 
 func validImpairmentTestDeps(ex *fakeExecutor) createDeps {
 	return impairmentTestDeps(ex, func(context.Context) (*LabState, error) {
-		return &LabState{Nodes: []string{"node1"}}, nil
+		return &LabState{Nodes: []string{"node1", "node2"}}, nil
 	})
 }
 

--- a/internal/lab/scenario.go
+++ b/internal/lab/scenario.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -15,32 +17,46 @@ const (
 
 	defaultRunsDir       = "runs"
 	defaultScenarioNode  = "node1"
+	defaultScenarioPeer  = "node2"
 	defaultScenarioIface = "eth0"
 	defaultUplinkBW      = "1mbit"
+	defaultBaseline      = 5 * time.Second
+	defaultImpaired      = 10 * time.Second
+	defaultRecovery      = 5 * time.Second
 )
 
 type ScenarioRunOptions struct {
-	Scenario  string
-	RunsDir   string
-	Node      string
-	Interface string
-	Delay     string
-	Loss      string
-	Jitter    string
-	BW        string
+	Scenario         string
+	RunsDir          string
+	Node             string
+	Peer             string
+	Interface        string
+	Delay            string
+	Loss             string
+	Jitter           string
+	BW               string
+	BaselineDuration time.Duration
+	ImpairedDuration time.Duration
+	RecoveryDuration time.Duration
+	StatsInterval    time.Duration
 }
 
 type ScenarioRunResult struct {
 	RunID      string
 	RunDir     string
+	LatestDir  string
 	EventsPath string
+	StatsPath  string
 }
 
 type scenarioRunDeps struct {
-	now      func() time.Time
-	newRunID func(time.Time) (string, error)
-	mkdirAll func(string, os.FileMode) error
-	openFile func(string, int, os.FileMode) (io.WriteCloser, error)
+	now        func() time.Time
+	newRunID   func(time.Time) (string, error)
+	mkdirAll   func(string, os.FileMode) error
+	openFile   func(string, int, os.FileMode) (io.WriteCloser, error)
+	executable func() (string, error)
+	runCommand func(context.Context, string, []string, io.Writer, io.Writer) error
+	sleep      func(time.Duration)
 }
 
 func RunScenario(ctx context.Context, opts ScenarioRunOptions) (*ScenarioRunResult, error) {
@@ -60,6 +76,16 @@ func runScenarioWithDeps(
 	if err := validateScenarioRunOptions(opts); err != nil {
 		return nil, err
 	}
+	webRTCOpts := WebRTCP2POptions{
+		RunsDir:       opts.RunsDir,
+		NodeA:         opts.Node,
+		NodeB:         opts.Peer,
+		Duration:      opts.BaselineDuration + opts.ImpairedDuration + opts.RecoveryDuration,
+		StatsInterval: opts.StatsInterval,
+	}
+	if err := validateWebRTCP2POptions(ctx, webRTCOpts, deps); err != nil {
+		return nil, err
+	}
 
 	startedAt := runDeps.now().UTC()
 	runID, err := runDeps.newRunID(startedAt)
@@ -71,10 +97,19 @@ func runScenarioWithDeps(
 	if err != nil {
 		return nil, err
 	}
+	if err := runDeps.mkdirAll(signalDir(logger.runDir), 0o755); err != nil {
+		return nil, errors.Join(fmt.Errorf("failed to create WebRTC signal directory: %w", err), logger.close())
+	}
+	latestDir, err := updateLatestRunSymlink(opts.RunsDir, runID)
+	if err != nil {
+		return nil, errors.Join(err, logger.close())
+	}
 	result := &ScenarioRunResult{
 		RunID:      logger.runID,
 		RunDir:     logger.runDir,
+		LatestDir:  latestDir,
 		EventsPath: logger.eventsPath,
+		StatsPath:  filepath.Join(logger.runDir, "stats.jsonl"),
 	}
 
 	condition := ImpairmentCondition{
@@ -101,9 +136,27 @@ func runScenarioWithDeps(
 	}
 
 	var runErr error
+	executable, err := runDeps.executable()
+	if err != nil {
+		runErr = errors.Join(runErr, fmt.Errorf("failed to resolve current executable: %w", err))
+	}
+	peerCtx, cancelPeers := context.WithCancel(ctx)
+	defer cancelPeers()
+	var waitPeers func() error
+	if err == nil {
+		waitPeers = startWebRTCPeerProcesses(peerCtx, webRTCOpts, runID, logger.runDir, executable, webRTCP2PDeps{
+			runCommand: runDeps.runCommand,
+		}, cancelPeers)
+		if readyErr := waitForWebRTCPeerReadiness(ctx, logger.runDir, []string{opts.Node, opts.Peer}, webRTCSignalTimeout); readyErr != nil {
+			runErr = errors.Join(runErr, readyErr)
+			cancelPeers()
+		}
+	}
+
 	if err := record("baseline", "start", "ok", nil); err != nil {
 		return result, errors.Join(err, logger.close())
 	}
+	runDeps.sleep(opts.BaselineDuration)
 
 	_, applyErr := applyWithDeps(ctx, ApplyOptions{
 		Node:   opts.Node,
@@ -118,6 +171,7 @@ func runScenarioWithDeps(
 	if err := record("impaired", "apply", statusForError(applyErr), applyErr); err != nil {
 		runErr = errors.Join(runErr, err)
 	}
+	runDeps.sleep(opts.ImpairedDuration)
 
 	if applyErr == nil {
 		recoveryResult, recoveryErr := clearWithDeps(ctx, ClearOptions{Node: opts.Node}, deps)
@@ -127,8 +181,11 @@ func runScenarioWithDeps(
 		if err := record("recovery", "clear", statusForClear(recoveryResult, recoveryErr), recoveryErr); err != nil {
 			runErr = errors.Join(runErr, err)
 		}
+		runDeps.sleep(opts.RecoveryDuration)
 	} else if err := record("recovery", "skip", "skipped", nil); err != nil {
 		runErr = errors.Join(runErr, err)
+	} else {
+		runDeps.sleep(opts.RecoveryDuration)
 	}
 
 	cleanupResult, cleanupErr := clearWithDeps(ctx, ClearOptions{Node: opts.Node}, deps)
@@ -137,6 +194,19 @@ func runScenarioWithDeps(
 	}
 	if err := record("cleanup", "clear", statusForClear(cleanupResult, cleanupErr), cleanupErr); err != nil {
 		runErr = errors.Join(runErr, err)
+	}
+	if waitPeers != nil {
+		if err := waitPeers(); err != nil {
+			runErr = errors.Join(runErr, err)
+		}
+	}
+	cancelPeers()
+	mergeErr := mergeStatsLogs(result.StatsPath, []string{
+		filepath.Join(logger.runDir, peerStatsFilename(opts.Node)),
+		filepath.Join(logger.runDir, peerStatsFilename(opts.Peer)),
+	})
+	if mergeErr != nil {
+		runErr = errors.Join(runErr, fmt.Errorf("failed to merge peer stats logs: %w", mergeErr))
 	}
 	if err := logger.close(); err != nil {
 		runErr = errors.Join(runErr, err)
@@ -149,6 +219,7 @@ func normalizeScenarioRunOptions(opts ScenarioRunOptions) ScenarioRunOptions {
 	opts.Scenario = strings.TrimSpace(opts.Scenario)
 	opts.RunsDir = strings.TrimSpace(opts.RunsDir)
 	opts.Node = strings.TrimSpace(opts.Node)
+	opts.Peer = strings.TrimSpace(opts.Peer)
 	opts.Interface = strings.TrimSpace(opts.Interface)
 	opts.Delay = strings.TrimSpace(opts.Delay)
 	opts.Loss = strings.TrimSpace(opts.Loss)
@@ -161,8 +232,23 @@ func normalizeScenarioRunOptions(opts ScenarioRunOptions) ScenarioRunOptions {
 	if opts.Node == "" {
 		opts.Node = defaultScenarioNode
 	}
+	if opts.Peer == "" {
+		opts.Peer = defaultScenarioPeer
+	}
 	if opts.Interface == "" {
 		opts.Interface = defaultScenarioIface
+	}
+	if opts.BaselineDuration <= 0 {
+		opts.BaselineDuration = defaultBaseline
+	}
+	if opts.ImpairedDuration <= 0 {
+		opts.ImpairedDuration = defaultImpaired
+	}
+	if opts.RecoveryDuration <= 0 {
+		opts.RecoveryDuration = defaultRecovery
+	}
+	if opts.StatsInterval <= 0 {
+		opts.StatsInterval = defaultWebRTCStatsInterval
 	}
 	if opts.Scenario == ScenarioWebRTCUplinkCongestion && opts.Delay == "" && opts.Loss == "" && opts.BW == "" {
 		opts.BW = defaultUplinkBW
@@ -176,6 +262,21 @@ func validateScenarioRunOptions(opts ScenarioRunOptions) error {
 	}
 	if opts.Interface != defaultScenarioIface {
 		return fmt.Errorf("unsupported interface %q: only %s is supported", opts.Interface, defaultScenarioIface)
+	}
+	if opts.Node == opts.Peer {
+		return errors.New("node and peer must be different")
+	}
+	if opts.BaselineDuration <= 0 {
+		return errors.New("baseline duration must be positive")
+	}
+	if opts.ImpairedDuration <= 0 {
+		return errors.New("impaired duration must be positive")
+	}
+	if opts.RecoveryDuration <= 0 {
+		return errors.New("recovery duration must be positive")
+	}
+	if opts.StatsInterval <= 0 {
+		return errors.New("stats interval must be positive")
 	}
 	if opts.Jitter != "" && opts.Delay == "" {
 		return errors.New("jitter requires delay")
@@ -200,6 +301,20 @@ func fillScenarioRunDeps(deps scenarioRunDeps) scenarioRunDeps {
 		deps.openFile = func(path string, flag int, perm os.FileMode) (io.WriteCloser, error) {
 			return os.OpenFile(path, flag, perm)
 		}
+	}
+	if deps.executable == nil {
+		deps.executable = os.Executable
+	}
+	if deps.runCommand == nil {
+		deps.runCommand = func(ctx context.Context, name string, args []string, stdout io.Writer, stderr io.Writer) error {
+			cmd := exec.CommandContext(ctx, name, args...)
+			cmd.Stdout = stdout
+			cmd.Stderr = stderr
+			return cmd.Run()
+		}
+	}
+	if deps.sleep == nil {
+		deps.sleep = time.Sleep
 	}
 	return deps
 }

--- a/internal/lab/scenario_test.go
+++ b/internal/lab/scenario_test.go
@@ -31,6 +31,16 @@ func TestRunScenarioWithDeps_WritesJSONLAndPhaseOrder(t *testing.T) {
 	if got.EventsPath != filepath.Join(runsDir, "run-test", "events.jsonl") {
 		t.Fatalf("unexpected events path: %s", got.EventsPath)
 	}
+	if got.StatsPath != filepath.Join(runsDir, "run-test", "stats.jsonl") {
+		t.Fatalf("unexpected stats path: %s", got.StatsPath)
+	}
+	latestTarget, err := os.Readlink(got.LatestDir)
+	if err != nil {
+		t.Fatalf("failed to read latest run link: %v", err)
+	}
+	if latestTarget != "run-test" {
+		t.Fatalf("latest run link = %s, want run-test", latestTarget)
+	}
 
 	events := readScenarioEvents(t, got.EventsPath)
 	assertPhases(t, events, []string{"baseline", "impaired", "recovery", "cleanup"})
@@ -50,6 +60,13 @@ func TestRunScenarioWithDeps_WritesJSONLAndPhaseOrder(t *testing.T) {
 	}
 	if countCall(ex.calls, "ip netns exec node1 tc qdisc del dev eth0 root") != 2 {
 		t.Fatalf("expected recovery and cleanup clear calls, calls=%v", ex.calls)
+	}
+	stats := readStatsRecords(t, got.StatsPath)
+	if len(stats) != 2 {
+		t.Fatalf("expected merged stats from two peers, got %+v", stats)
+	}
+	if stats[0].Node != "node2" || stats[1].Node != "node1" {
+		t.Fatalf("unexpected stats order: %+v", stats)
 	}
 }
 
@@ -148,10 +165,11 @@ func TestRunScenarioWithDeps_ClearFailureLoggedAsError(t *testing.T) {
 func TestRunScenarioWithDeps_LogWriteFailureReturnsErrorAndCleansUp(t *testing.T) {
 	ex := scenarioTestExecutor(nil)
 	writer := &failingWriteCloser{failOn: 2}
+	runsDir := filepath.Join(t.TempDir(), "runs")
 
 	_, err := runScenarioWithDeps(
 		context.Background(),
-		ScenarioRunOptions{Scenario: ScenarioWebRTCUplinkCongestion, RunsDir: "runs"},
+		ScenarioRunOptions{Scenario: ScenarioWebRTCUplinkCongestion, RunsDir: runsDir},
 		validImpairmentTestDeps(ex),
 		scenarioRunDeps{
 			now: func() time.Time {
@@ -160,12 +178,15 @@ func TestRunScenarioWithDeps_LogWriteFailureReturnsErrorAndCleansUp(t *testing.T
 			newRunID: func(time.Time) (string, error) {
 				return "run-write-failure", nil
 			},
-			mkdirAll: func(string, os.FileMode) error {
-				return nil
-			},
+			mkdirAll: os.MkdirAll,
 			openFile: func(string, int, os.FileMode) (io.WriteCloser, error) {
 				return writer, nil
 			},
+			executable: func() (string, error) {
+				return "/tmp/rtc-emulator", nil
+			},
+			runCommand: fakeScenarioWebRTCPeerCommand,
+			sleep:      func(time.Duration) {},
 		},
 	)
 	if err == nil || !strings.Contains(err.Error(), "failed to write event log") {
@@ -184,7 +205,7 @@ func scenarioTestExecutor(runFn func(name string, args ...string) error) *fakeEx
 		runFn: runFn,
 		outputFn: func(name string, args ...string) (string, error) {
 			if callKey(name, args...) == "ip netns list" {
-				return "node1\n", nil
+				return "node1\nnode2\n", nil
 			}
 			return "", nil
 		},
@@ -199,7 +220,45 @@ func fixedScenarioRunDeps(runID string) scenarioRunDeps {
 		newRunID: func(time.Time) (string, error) {
 			return runID, nil
 		},
+		executable: func() (string, error) {
+			return "/tmp/rtc-emulator", nil
+		},
+		runCommand: fakeScenarioWebRTCPeerCommand,
+		sleep:      func(time.Duration) {},
 	}
+}
+
+func fakeScenarioWebRTCPeerCommand(_ context.Context, name string, args []string, _ io.Writer, _ io.Writer) error {
+	if name != "ip" {
+		return nil
+	}
+	runID := argValue(args, "--run-id")
+	runDir := argValue(args, "--run-dir")
+	node := argValue(args, "--node")
+	peer := argValue(args, "--peer")
+	state := &webRTCPeerRuntimeState{
+		peerConnection: "connected",
+		iceConnection:  "connected",
+	}
+	if err := writePeerConnectedMarker(runDir, WebRTCPeerOptions{
+		RunID: runID,
+		Node:  node,
+		Peer:  peer,
+	}, state); err != nil {
+		return err
+	}
+	statsTime := "2026-06-21T12:00:02Z"
+	if node == "node2" {
+		statsTime = "2026-06-21T12:00:01Z"
+	}
+	return writeOneStatsRecord(filepath.Join(runDir, peerStatsFilename(node)), WebRTCStatsRecord{
+		RunID:               runID,
+		Time:                statsTime,
+		Node:                node,
+		Peer:                peer,
+		PeerConnectionState: "connected",
+		ICEConnectionState:  "connected",
+	})
 }
 
 func readScenarioEvents(t *testing.T, path string) []EventRecord {

--- a/internal/lab/webrtc_p2p.go
+++ b/internal/lab/webrtc_p2p.go
@@ -263,8 +263,30 @@ func runWebRTCPeerProcesses(
 	onConnected func() error,
 ) error {
 	ctx, cancel := context.WithCancel(ctx)
+	wait := startWebRTCPeerProcesses(ctx, opts, runID, runDir, executable, deps, cancel)
 	defer cancel()
 
+	readyErr := waitForWebRTCPeerReadiness(ctx, runDir, []string{opts.NodeA, opts.NodeB}, webRTCSignalTimeout)
+	if readyErr != nil {
+		cancel()
+	} else if onConnected != nil {
+		readyErr = onConnected()
+		if readyErr != nil {
+			cancel()
+		}
+	}
+	return errors.Join(readyErr, wait())
+}
+
+func startWebRTCPeerProcesses(
+	ctx context.Context,
+	opts WebRTCP2POptions,
+	runID string,
+	runDir string,
+	executable string,
+	deps webRTCP2PDeps,
+	cancel context.CancelFunc,
+) func() error {
 	type peerProc struct {
 		node   string
 		role   string
@@ -301,24 +323,17 @@ func runWebRTCPeerProcesses(
 		}()
 	}
 
-	readyErr := waitForWebRTCPeerReadiness(ctx, runDir, []string{opts.NodeA, opts.NodeB}, webRTCSignalTimeout)
-	if readyErr != nil {
-		cancel()
-	} else if onConnected != nil {
-		readyErr = onConnected()
-		if readyErr != nil {
-			cancel()
-		}
-	}
-	wg.Wait()
+	return func() error {
+		wg.Wait()
 
-	var runErr error = readyErr
-	for _, proc := range procs {
-		if proc.err != nil {
-			runErr = errors.Join(runErr, fmt.Errorf("webrtc peer %s/%s failed: %w stdout=%q stderr=%q", proc.node, proc.role, proc.err, proc.stdout.String(), proc.stderr.String()))
+		var runErr error
+		for _, proc := range procs {
+			if proc.err != nil {
+				runErr = errors.Join(runErr, fmt.Errorf("webrtc peer %s/%s failed: %w stdout=%q stderr=%q", proc.node, proc.role, proc.err, proc.stdout.String(), proc.stderr.String()))
+			}
 		}
+		return runErr
 	}
-	return runErr
 }
 
 func webRTCPeerNetNSArgs(node string, executable string, opts WebRTCPeerOptions) []string {


### PR DESCRIPTION
## Summary
- connect `lab scenario run webrtc-uplink-congestion` to the built-in Pion P2P runner
- run baseline, impaired, recovery, and cleanup phases while collecting WebRTC stats under the same run ID
- add scenario flags for peer node, phase durations, and stats interval
- write merged `stats.jsonl`, update `runs/latest`, and document manual verification notes

## Tests
- `go test ./...`
- `go build ./cmd/rtc-emulator`
- `go run ./cmd/rtc-emulator lab scenario run --help`

Closes #26